### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk8
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ For more information, please visit [Organic Buidler website](https://bertranddec
 
 You are welcome to watch, fork the project and create pull requests. Contact me if you have any questions.
 
+![Travis build status](https://travis-ci.org/BertrandDechoux/OrganicBuilder.svg?branch=develop)
 
 **Compile and run the tests**
 ```


### PR DESCRIPTION
Add travis configuration file (OrganicBuider requires oracle jdk 1.8.40) and visual feedback in the readme (travis image for build status).

See issue #7 Automatic Build with travis
